### PR TITLE
have README say to run main.py instead of req.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It needs to be found in your `PATH` variable.
 
 `export PATH=$PATH:$(pwd)`
 
-`python req.py` to run. It will loop until you kill the job. `ctrl + c` in your terminal to give the pro lifes a break (optional).
+`python main.py` to run. It will loop until you kill the job. `ctrl + c` in your terminal to give the pro lifes a break (optional).
 
 mac:
 


### PR DESCRIPTION
Just small but especially for beginners this is something that could throw them off/make them think they are missing something.