### PR TITLE
Consistent format for constants maps

### DIFF
--- a/constants/location.py
+++ b/constants/location.py
@@ -1,8 +1,9 @@
-CITIES_TO_STATES = {'Lancaster': 'Pennsylvania',
-                    'Omaha': 'Nebraska',
-                    'Battle Creek': 'Michigan',
-                    'Memphis': 'Tennessee',
-                    }
+CITIES_TO_STATES = {
+    'Lancaster': 'Pennsylvania',
+    'Omaha': 'Nebraska',
+    'Battle Creek': 'Michigan',
+    'Memphis': 'Tennessee',
+}
 
 CITIES_TO_ZIP_CODES = {
     'Lancaster': ['17573', '17601', '17602', '17605', '17606', '17699'],


### PR DESCRIPTION
All the other maps in this file and in `xPaths.py` use this whitespace format. 
